### PR TITLE
same as the last one, but in the rework branch.

### DIFF
--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -70,6 +70,7 @@ const QString PSI4_EXECUTABLE = PSI4_GROUP + "/executablePath";
 const QString OCC_GROUP = "occ";
 const QString OCC_EXECUTABLE = OCC_GROUP + "/executablePath";
 const QString OCC_DATA_DIRECTORY = OCC_GROUP + "/dataDirectory";
+const QString OCC_PATH = OCC_GROUP + "";
 const QString OCC_NTHREADS = OCC_GROUP + "/numThreads";
 
 // Orca

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -70,7 +70,7 @@ const QString PSI4_EXECUTABLE = PSI4_GROUP + "/executablePath";
 const QString OCC_GROUP = "occ";
 const QString OCC_EXECUTABLE = OCC_GROUP + "/executablePath";
 const QString OCC_DATA_DIRECTORY = OCC_GROUP + "/dataDirectory";
-const QString OCC_PATH = OCC_GROUP + "";
+const QString OCC_PATH = "/usr/local/bin";
 const QString OCC_NTHREADS = OCC_GROUP + "/numThreads";
 
 // Orca

--- a/src/graphics/chemicalstructurerenderer.cpp
+++ b/src/graphics/chemicalstructurerenderer.cpp
@@ -605,7 +605,7 @@ void ChemicalStructureRenderer::handleMeshesUpdate() {
         int propertyIndex =
             availableProperties.indexOf(meshInstance->getSelectedProperty());
         // TODO transparency
-        float alpha = meshInstance->isTransparent() ? 0.8 : 1.0;
+        float alpha = meshInstance->isTransparent() ? 0.9 : 1.0;
 
         QVector3D selectionColor;
 

--- a/src/occ/include/occ/3rdparty/eigen-fmt/fmt.h
+++ b/src/occ/include/occ/3rdparty/eigen-fmt/fmt.h
@@ -125,7 +125,7 @@ std::string format(const T &matrix, const FormatSpec &fmt) {
 
   auto out = fmt::memory_buffer();
   if (matrix.size() == 0) {
-    format_to(std::back_inserter(out), "{}{}", fmt.mat_prefix, fmt.mat_suffix);
+    fmt::format_to(std::back_inserter(out), "{}{}", fmt.mat_prefix, fmt.mat_suffix);
     return {out.data(), out.size()};
   }
 
@@ -159,22 +159,22 @@ std::string format(const T &matrix, const FormatSpec &fmt) {
   auto print_coeff = [&width, &out, &explicit_precision](const Scalar &v) {
     if (width > 0) {
       if (explicit_precision != 0) {
-        format_to(std::back_inserter(out), "{:{}.{}}", v, width,
+        fmt::format_to(std::back_inserter(out), "{:{}.{}}", v, width,
                   explicit_precision);
       } else {
-        format_to(std::back_inserter(out), "{:{}}", v, width);
+        fmt::format_to(std::back_inserter(out), "{:{}}", v, width);
       }
     } else {
       if (explicit_precision != 0) {
-        format_to(std::back_inserter(out), "{:.{}}", v, explicit_precision);
+        fmt::format_to(std::back_inserter(out), "{:.{}}", v, explicit_precision);
       } else {
-        format_to(std::back_inserter(out), "{}", v);
+        fmt::format_to(std::back_inserter(out), "{}", v);
       }
     }
   };
 
   auto print_string = [&out](const std::string &str) {
-    format_to(std::back_inserter(out), "{}", str);
+    fmt::format_to(std::back_inserter(out), "{}", str);
   };
 
   if (!fmt.dont_align_cols) {
@@ -364,7 +364,7 @@ struct formatter<
         // return print_matrix(data, ctx);
         ss << data.format(formatter);
       }
-      return format_to(ctx.out(), "{}", ss.str());
+      return fmt::format_to(ctx.out(), "{}", ss.str());
 #else
       return print_matrix(data, ctx);
 #endif
@@ -385,7 +385,7 @@ struct formatter<
   //! character parsed
   template <typename U>
   auto print_matrix(const U &data, format_context &ctx) -> decltype(ctx.out()) {
-    return format_to(ctx.out(), "{}", EigenFmt::format(data, format_));
+    return fmt::format_to(ctx.out(), "{}", EigenFmt::format(data, format_));
   }
 
   EigenFmt::FormatSpec format_;

--- a/src/occ/include/occ/core/kdtree.h
+++ b/src/occ/include/occ/core/kdtree.h
@@ -2,7 +2,7 @@
 #include <occ/3rdparty/nanoflann.hpp>
 #include <occ/core/linear_algebra.h>
 #include <vector>
-
+#include <memory>
 namespace occ::core {
 
 template <typename NumericType>


### PR DESCRIPTION
Apparently format_to is an intrinsic in newer C++ versions. As there was a conflict when I was trying to compile I solved it this way.