### PR TITLE
Enables multithreading/multiprocessing in Orca and OCC.

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -17,7 +17,7 @@ static const QMap<QString, QVariant> defaults{
     {keys::NWCHEM_EXECUTABLE, ""},
     {keys::PSI4_EXECUTABLE, ""},
     {keys::ORCA_EXECUTABLE, ""},
-    {keys::ORCA_NTHREADS, ""},
+    {keys::ORCA_NTHREADS, 1},
     {keys::XTB_EXECUTABLE, ""},
     {keys::OCC_NTHREADS, 1},
     {keys::OCC_EXECUTABLE, ""},

--- a/src/exe/occsurfacetask.cpp
+++ b/src/exe/occsurfacetask.cpp
@@ -89,7 +89,7 @@ QString OccSurfaceTask::kind() const {
 float OccSurfaceTask::separation() const { return m_parameters.separation; }
 
 int OccSurfaceTask::threads() const {
-  return properties().value("threads", settings::readSetting("occ/numThreads").toInt()).toInt();
+  return properties().value("threads", settings::readSetting(settings::keys::OCC_NTHREADS).toInt()).toInt();
 }
 
 float OccSurfaceTask::isovalue() const {

--- a/src/exe/occsurfacetask.cpp
+++ b/src/exe/occsurfacetask.cpp
@@ -1,6 +1,7 @@
 #include "occsurfacetask.h"
 #include "exefileutilities.h"
 #include "filedependency.h"
+#include "settings.h"
 
 OccSurfaceTask::OccSurfaceTask(QObject *parent) : ExternalProgramTask(parent) {
   setExecutable(exe::findProgramInPath("occ"));
@@ -88,7 +89,7 @@ QString OccSurfaceTask::kind() const {
 float OccSurfaceTask::separation() const { return m_parameters.separation; }
 
 int OccSurfaceTask::threads() const {
-  return properties().value("threads", 6).toInt();
+  return properties().value("threads", settings::readSetting("occ/numThreads").toInt()).toInt();
 }
 
 float OccSurfaceTask::isovalue() const {

--- a/src/exe/occwavefunctiontask.cpp
+++ b/src/exe/occwavefunctiontask.cpp
@@ -19,6 +19,9 @@ const wfn::Parameters &OccWavefunctionTask::getParameters() const {
   return m_parameters;
 }
 
+int OccWavefunctionTask::threads() const {
+  return properties().value("threads", 6).toInt();
+}
 void OccWavefunctionTask::start() {
   QString json = m_parameters.userInputContents;
   if (!m_parameters.userEditRequested) {
@@ -30,14 +33,15 @@ void OccWavefunctionTask::start() {
   QString name = baseName();
   QString inputName = name + inputSuffix();
   QString outputName = wavefunctionFilename();
-
+  QStringList args{"scf", inputName};
   if (!io::writeTextFile(inputName, json)) {
     emit errorOccurred("Could not write input file: " + inputName);
     return;
   }
   emit progressText("Wrote input file");
 
-  setArguments({"scf", inputName});
+  args << QString("--threads=%1").arg(threads());
+  setArguments(args);
   setRequirements({FileDependency(inputName)});
   setOutputs({FileDependency(outputName, outputName)});
 

--- a/src/exe/occwavefunctiontask.cpp
+++ b/src/exe/occwavefunctiontask.cpp
@@ -21,7 +21,7 @@ const wfn::Parameters &OccWavefunctionTask::getParameters() const {
 }
 
 int OccWavefunctionTask::threads() const {
-  return properties().value("threads", settings::readSetting("occ/numThreads")).toInt();
+  return properties().value("threads", settings::readSetting(settings::keys::OCC_NTHREADS).toInt()).toInt();
 }
 void OccWavefunctionTask::start() {
   QString json = m_parameters.userInputContents;

--- a/src/exe/occwavefunctiontask.cpp
+++ b/src/exe/occwavefunctiontask.cpp
@@ -3,6 +3,7 @@
 #include "filedependency.h"
 #include "occinput.h"
 #include <fmt/core.h>
+#include "settings.h"
 #include <occ/core/element.h>
 
 OccWavefunctionTask::OccWavefunctionTask(QObject *parent)
@@ -20,7 +21,7 @@ const wfn::Parameters &OccWavefunctionTask::getParameters() const {
 }
 
 int OccWavefunctionTask::threads() const {
-  return properties().value("threads", 6).toInt();
+  return properties().value("threads", settings::readSetting("occ/numThreads")).toInt();
 }
 void OccWavefunctionTask::start() {
   QString json = m_parameters.userInputContents;

--- a/src/exe/occwavefunctiontask.h
+++ b/src/exe/occwavefunctiontask.h
@@ -17,6 +17,7 @@ public:
   QString inputSuffix() const;
   QString wavefunctionSuffix() const;
   QString wavefunctionFilename() const;
+  int threads() const;
 
 private:
   wfn::Parameters m_parameters;

--- a/src/io/orcainput.cpp
+++ b/src/io/orcainput.cpp
@@ -7,7 +7,7 @@ namespace io {
 QString orcaInputString(const wfn::Parameters &params) {
   QByteArray destination;
   QTextStream ts(&destination);
-  int numProcs = settings::readSetting("orca/numProcs").toInt();
+  int numProcs = settings::readSetting(settings::keys::ORCA_NTHREADS).toInt();
   numProcs = numProcs == 0 ? 1 : numProcs;
   ts << "! " << params.method << " " << params.basis << Qt::endl;
   ts << "%PAL NPROCS " << numProcs << " END" << Qt::endl;

--- a/src/io/orcainput.cpp
+++ b/src/io/orcainput.cpp
@@ -1,14 +1,16 @@
 #include "orcainput.h"
 #include "chemicalstructure.h"
 #include <occ/core/element.h>
-
+#include "settings.h"
 namespace io {
 
 QString orcaInputString(const wfn::Parameters &params) {
   QByteArray destination;
   QTextStream ts(&destination);
-
+  int numProcs = settings::readSetting("orca/numProcs").toInt();
+  numProcs = numProcs == 0 ? 1 : numProcs;
   ts << "! " << params.method << " " << params.basis << Qt::endl;
+  ts << "%PAL NPROCS " << numProcs << " END" << Qt::endl;
   auto nums = params.structure->atomicNumbersForIndices(params.atoms);
   auto pos = params.structure->atomicPositionsForIndices(params.atoms);
 


### PR DESCRIPTION
A while ago, I realized that CE wasn't using multithreading for wavefunction calculations, neither in Orca nor in OCC. This PR addresses this issue. It also makes the surface calculation respect the number of threads defined in settings (it was always using 6). I think it would be better if we used SpinBoxes in the layout with maximum values that follow Orca's instance against hyperthreading and MPI problems. But for now, I think this makes the program more usable. 

I would also like to ask, what do you think about using hyperthreading in OCC? Have you done benchmarks? Sane defaults and maximum values for both wavefunction sources would be better. 