### PR TITLE
Export color bar in scene previews and export images

### DIFF
--- a/src/glwindow.cpp
+++ b/src/glwindow.cpp
@@ -454,6 +454,18 @@ QImage GLWindow::exportToImage(int scaleFactor, const QColor &background) {
   fbo.release();
 
   QImage result(fbo.toImage());
+  // Render the color bar widget on top of the exported scene image if it exists
+  if (m_colorBar!=NULL && m_colorBar->isVisible()) {
+
+    QPainter painter(&result);
+
+    QPoint pos = m_colorBar->pos() * scaleFactor;
+    painter.translate(pos);
+
+    painter.scale(scaleFactor, scaleFactor);
+
+    m_colorBar->render(&painter);
+  }
   const QColor &color = scene->backgroundColor();
   glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
   glClearDepth(0);
@@ -486,10 +498,23 @@ QImage GLWindow::renderToImage(int scaleFactor, bool for_picking) {
   fbo.release();
 
   QImage result(fbo.toImage());
+
   if (for_picking) {
     const QColor &color = scene->backgroundColor();
     glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
     glClearDepth(0);
+  }
+  // Adding colorbar widget to the preview if it exists
+  else if (!for_picking && m_colorBar!=NULL && m_colorBar->isVisible()) {
+
+    QPainter painter(&result);
+
+    QPoint pos = m_colorBar->pos() * scaleFactor;
+
+    painter.translate(pos);
+    painter.scale(scaleFactor, scaleFactor);
+
+    m_colorBar->render(&painter);
   }
   doneCurrent();
   return result;


### PR DESCRIPTION
Previously the color bar was only drawn on-screen as an overlay, so it didn’t appear in exported images or previews.  

This adds a check in `GLWindow::exportToImage()` and `GLWindow::renderToImage()` to draw the color bar on top of the exported scene when it exists and is visible

Fixes #45 